### PR TITLE
Organize directory structure more robustly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,7 +138,8 @@ cython_debug/
 *.sqlite3
 *.sql
 
-
-
 # VS Code
 .vscode/
+
+# IntelliJ IDEA
+.idea/


### PR DESCRIPTION
Update `.gitignore` to exclude IDE-specific directories.

* Add `.idea/` directory to `.gitignore` to exclude IntelliJ IDEA configuration files.
* Move `.vscode/` exclusion to a more appropriate section within `.gitignore`.

